### PR TITLE
Zephyr Patches for Wi-Fi bypass support

### DIFF
--- a/drivers/wifi/winc1500/Kconfig.winc1500
+++ b/drivers/wifi/winc1500/Kconfig.winc1500
@@ -61,6 +61,15 @@ config WIFI_WINC1500_OFFLOAD_MAX_SOCKETS
 	  Set the number of sockets that can be managed through the driver
 	  and the chip.
 
+config WIFI_WINC1500_BYPASS_MODE
+	bool "Use ETHERNET bypass mode instead of the WINC TCP/IP stack"
+	select WIFI_USE_NATIVE_NETWORKING
+	select NET_L2_ETHERNET
+	help
+	  Should we exchange raw Ethernet frames with Zephyr instead of using the
+	  WINC TCP/IP stack? Requires the ETH_MODE compile definition, and the
+	  application must supply the interface address and a DHCP server.
+
 choice
 	bool "In which region is the chip running?"
 	default WIFI_WINC1500_REGION_NORTH_AMERICA

--- a/drivers/wifi/winc1500/wifi_winc1500.c
+++ b/drivers/wifi/winc1500/wifi_winc1500.c
@@ -19,6 +19,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_l2.h>
 #include <zephyr/net/net_context.h>
+#include <zephyr/net/ethernet.h>
 #include <zephyr/net/net_offload.h>
 #include <zephyr/net/wifi_mgmt.h>
 #include <zephyr/net/conn_mgr/connectivity_wifi_mgmt.h>
@@ -1108,15 +1109,25 @@ static void winc1500_iface_init(struct net_if *iface)
 	net_if_set_link_addr(iface, w1500_data.mac, sizeof(w1500_data.mac),
 			     NET_LINK_ETHERNET);
 
+#ifdef ETH_MODE
+	/* Must set the type, net_if_is_wifi() answers false for a native interface without it */
+	struct ethernet_context *eth_ctx = net_if_l2_data(iface);
+
+	eth_ctx->eth_if_type = L2_ETH_IF_TYPE_WIFI;
+	ethernet_init(iface);
+#else
 	iface->if_dev->offload = &winc1500_offload;
+#endif
 
 	w1500_data.iface = iface;
 }
 
+#ifndef ETH_MODE
 static enum offloaded_net_if_types winc1500_get_wifi_type(void)
 {
 	return L2_OFFLOADED_NET_IF_TYPE_WIFI;
 }
+#endif /* !ETH_MODE */
 
 static const struct wifi_mgmt_ops winc1500_mgmt_ops = {
 	.scan		= winc1500_mgmt_scan,
@@ -1125,16 +1136,112 @@ static const struct wifi_mgmt_ops winc1500_mgmt_ops = {
 	.ap_enable	= winc1500_mgmt_ap_enable,
 	.ap_disable	= winc1500_mgmt_ap_disable,
 };
+#ifdef ETH_MODE
+static int winc1500_eth_send(const struct device *dev, struct net_pkt *pkt);
+static enum ethernet_hw_caps winc1500_eth_caps(const struct device *dev);
+
+static const struct net_wifi_mgmt_offload winc1500_api = {
+	.wifi_iface.iface_api.init = winc1500_iface_init,
+	.wifi_iface.send = winc1500_eth_send,
+	.wifi_iface.get_capabilities = winc1500_eth_caps,
+	.wifi_mgmt_api = &winc1500_mgmt_ops,
+};
+#else
 static const struct net_wifi_mgmt_offload winc1500_api = {
 	.wifi_iface.iface_api.init = winc1500_iface_init,
 	.wifi_iface.get_type = winc1500_get_wifi_type,
 	.wifi_mgmt_api = &winc1500_mgmt_ops,
 };
+#endif /* ETH_MODE */
+
+#ifdef ETH_MODE
+static uint8_t bypass_rx_buffer[CONFIG_WIFI_WINC1500_MAX_PACKET_SIZE];
+
+static void winc1500_bypass_eth_cb(uint8 u8MsgType, void *pvMsg, void *pvCtrlBuf)
+{
+	tstrM2mIpCtrlBuf *ctrl_buf = (tstrM2mIpCtrlBuf *)pvCtrlBuf;
+	const uint8_t *frame = (const uint8_t *)pvMsg;
+	struct net_pkt *pkt;
+
+	if (u8MsgType != M2M_WIFI_RESP_ETHERNET_RX_PACKET) {
+		return;
+	}
+
+	if (ctrl_buf == NULL || frame == NULL || ctrl_buf->u16DataSize == 0U) {
+		return;
+	}
+
+	if (w1500_data.iface == NULL) {
+		LOG_ERR("Frame received before the interface exists, dropping");
+		return;
+	}
+
+	/* Must be AF_UNSPEC, this is a whole frame and ETHERNET_L2 reads the header itself */
+	pkt = net_pkt_rx_alloc_with_buffer(w1500_data.iface, ctrl_buf->u16DataSize,
+					   AF_UNSPEC, 0, K_MSEC(100));
+	if (pkt == NULL) {
+		LOG_ERR("Could not allocate an rx packet for %u bytes", ctrl_buf->u16DataSize);
+		return;
+	}
+
+	if (net_pkt_write(pkt, frame, ctrl_buf->u16DataSize) < 0) {
+		LOG_ERR("Could not write %u bytes into the rx packet", ctrl_buf->u16DataSize);
+		net_pkt_unref(pkt);
+		return;
+	}
+
+	if (net_recv_data(w1500_data.iface, pkt) < 0) {
+		LOG_ERR("Stack refused a received frame");
+		net_pkt_unref(pkt);
+	}
+}
+
+static int winc1500_eth_send(const struct device *dev, struct net_pkt *pkt)
+{
+	static uint8_t tx_buffer[CONFIG_WIFI_WINC1500_MAX_PACKET_SIZE];
+	size_t length = net_pkt_get_len(pkt);
+
+	ARG_UNUSED(dev);
+
+	if (length > sizeof(tx_buffer)) {
+		LOG_ERR("Frame of %zu bytes exceeds the %zu byte transmit buffer", length,
+			sizeof(tx_buffer));
+		return -EMSGSIZE;
+	}
+
+	if (net_pkt_read(pkt, tx_buffer, length) < 0) {
+		LOG_ERR("Could not read a %zu byte frame into the send buffer", length);
+		return -EIO;
+	}
+
+	if (m2m_wifi_send_ethernet_pkt(tx_buffer, length) != M2M_SUCCESS) {
+		LOG_ERR("m2m_wifi_send_ethernet_pkt failed for %zu bytes", length);
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static enum ethernet_hw_caps winc1500_eth_caps(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE;
+}
+#endif /* ETH_MODE */
 
 static int winc1500_init(const struct device *dev)
 {
 	tstrWifiInitParam param = {
 		.pfAppWifiCb = winc1500_wifi_cb,
+#ifdef ETH_MODE
+		.strEthInitParam = {
+			.pfAppWifiCb = winc1500_wifi_cb,
+			.pfAppEthCb = winc1500_bypass_eth_cb,
+			.au8ethRcvBuf = bypass_rx_buffer,
+			.u16ethRcvBufSize = sizeof(bypass_rx_buffer),
+			.u8EthernetEnable = M2M_WIFI_MODE_ETHERNET,
+		},
+#endif /* ETH_MODE */
 	};
 	unsigned char is_valid;
 	int ret;
@@ -1150,8 +1257,10 @@ static int winc1500_init(const struct device *dev)
 		return -EIO;
 	}
 
+#ifndef ETH_MODE
 	socketInit();
 	registerSocketCallback(winc1500_socket_cb, NULL);
+#endif /* !ETH_MODE */
 
 	if (m2m_wifi_get_otp_mac_address(w1500_data.mac, &is_valid) != M2M_SUCCESS) {
 		LOG_ERR("Failed to get MAC address");
@@ -1188,9 +1297,16 @@ static int winc1500_init(const struct device *dev)
 	return 0;
 }
 
+#ifdef ETH_MODE
+NET_DEVICE_INIT(winc1500, CONFIG_WIFI_WINC1500_NAME,
+		winc1500_init, NULL, &w1500_data, NULL,
+		CONFIG_WIFI_INIT_PRIORITY, &winc1500_api, ETHERNET_L2,
+		NET_L2_GET_CTX_TYPE(ETHERNET_L2), NET_ETH_MTU);
+#else
 NET_DEVICE_OFFLOAD_INIT(winc1500, CONFIG_WIFI_WINC1500_NAME,
 			winc1500_init, NULL, &w1500_data, NULL,
 			CONFIG_WIFI_INIT_PRIORITY, &winc1500_api,
 			CONFIG_WIFI_WINC1500_MAX_PACKET_SIZE);
+#endif /* ETH_MODE */
 
 CONNECTIVITY_WIFI_MGMT_BIND(winc1500);

--- a/include/zephyr/shell/shell_telnet.h
+++ b/include/zephyr/shell/shell_telnet.h
@@ -60,6 +60,11 @@ struct shell_telnet {
 	struct k_work_delayable send_work;
 	struct k_work_sync work_sync;
 
+#if defined(CONFIG_SHELL_TELNET_RESTART)
+	/** Retries the listening socket after the bound interface goes down. */
+	struct k_work_delayable restart_work;
+#endif
+
 	/** If set, no output is sent to the TELNET client. */
 	bool output_lock;
 };

--- a/subsys/net/ip/Kconfig.ipv4
+++ b/subsys/net/ip/Kconfig.ipv4
@@ -97,6 +97,13 @@ config NET_IPV4_ACCEPT_ZERO_BROADCAST
 	  If set, then accept UDP packets destined to non-standard
 	  0.0.0.0 broadcast address as described in RFC 1122 ch. 3.3.6
 
+config NET_IPV4_FORWARDING
+	bool "Forward IPv4 unicast packets between interfaces"
+	help
+	  If set, forward unicast packets that are not addressed to this device to
+	  the interface whose subnet contains the destination. Only directly
+	  attached subnets are reachable and addresses are not translated.
+
 config NET_IPV4_IGMP
 	bool "Internet Group Management Protocol (IGMPv2) support"
 	select NET_IPV4_HDR_OPTIONS

--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -240,6 +240,121 @@ int net_ipv4_parse_hdr_options(struct net_pkt *pkt,
 }
 #endif
 
+#if defined(CONFIG_NET_IPV4_FORWARDING)
+
+struct ipv4_dst_iface_lookup {
+	const struct in_addr *dst;
+	struct net_if *orig_iface;
+	struct net_if *dst_iface;
+};
+
+static void ipv4_dst_iface_cb(struct net_if *iface, void *user_data)
+{
+	struct ipv4_dst_iface_lookup *lookup = (struct ipv4_dst_iface_lookup *)user_data;
+
+	if (lookup->dst_iface != NULL || iface == lookup->orig_iface) {
+		return;
+	}
+
+	/* Must not use net_if_ipv4_select_src_iface(), it falls back to the default interface */
+	if (net_if_ipv4_addr_mask_cmp(iface, lookup->dst)) {
+		lookup->dst_iface = iface;
+	}
+}
+
+/* Forward a unicast packet to the interface that owns its destination subnet */
+static enum net_verdict ipv4_forward_packet(struct net_pkt *pkt, struct net_ipv4_hdr *hdr,
+					    struct net_pkt_data_access *ipv4_access)
+{
+	struct net_if *orig_iface = net_pkt_iface(pkt);
+	struct ipv4_dst_iface_lookup lookup = { 0 };
+	struct in_addr dst;
+	uint32_t chksum;
+	int ret;
+
+	if (net_ipv4_is_addr_mcast_raw(hdr->dst) ||
+	    net_ipv4_is_addr_bcast_raw(orig_iface, hdr->dst) ||
+	    net_ipv4_is_addr_unspecified_raw(hdr->dst) ||
+	    net_ipv4_is_addr_loopback_raw(hdr->dst)) {
+		return NET_DROP;
+	}
+
+	net_ipv4_addr_copy_raw((uint8_t *)&dst, hdr->dst);
+
+	lookup.dst = &dst;
+	lookup.orig_iface = orig_iface;
+	net_if_foreach(ipv4_dst_iface_cb, &lookup);
+
+	if (lookup.dst_iface == NULL) {
+		return NET_DROP;
+	}
+
+	if (hdr->ttl <= 1U) {
+		NET_DBG("DROP: TTL expired while forwarding to %s", net_sprint_ipv4_addr(&dst));
+		return NET_DROP;
+	}
+
+	/* Re-acquire at a known cursor, the header passed in can be a copy on the stack */
+	net_pkt_cursor_init(pkt);
+
+	hdr = (struct net_ipv4_hdr *)net_pkt_get_data(pkt, ipv4_access);
+	if (hdr == NULL) {
+		NET_DBG("DROP: cannot reach the header of a packet to forward");
+		return NET_DROP;
+	}
+
+	hdr->ttl--;
+
+	/* Incremental checksum update, RFC 1624 */
+	chksum = (uint32_t)ntohs(hdr->chksum) + 0x0100U;
+	chksum += (chksum >= 0xFFFFU);
+	hdr->chksum = htons((uint16_t)chksum);
+
+	/* Must write back, hdr can be a copy on the stack */
+	if (net_pkt_set_data(pkt, ipv4_access) < 0) {
+		NET_DBG("DROP: cannot write the forwarded header back");
+		return NET_DROP;
+	}
+
+	net_pkt_cursor_init(pkt);
+
+	net_pkt_set_orig_iface(pkt, orig_iface);
+	net_pkt_set_iface(pkt, lookup.dst_iface);
+	net_pkt_set_forwarding(pkt, true);
+	net_pkt_set_ll_proto_type(pkt, NET_ETH_PTYPE_IP);
+
+	/* Only the source is set here, L2 resolves the next hop */
+	(void)net_linkaddr_set(net_pkt_lladdr_src(pkt), net_pkt_lladdr_if(pkt)->addr,
+			       net_pkt_lladdr_if(pkt)->len);
+
+	NET_DBG("Forwarding %s to iface %d", net_sprint_ipv4_addr(&dst),
+		net_if_get_by_iface(lookup.dst_iface));
+
+	ret = net_send_data(pkt);
+	if (ret < 0) {
+		/* Put the interface back, the caller counts the drop against it */
+		NET_DBG("DROP: cannot forward to iface %d (%d)",
+			net_if_get_by_iface(lookup.dst_iface), ret);
+		net_pkt_set_iface(pkt, orig_iface);
+		net_pkt_set_forwarding(pkt, false);
+
+		return NET_DROP;
+	}
+
+	return NET_OK;
+}
+#else
+static inline enum net_verdict ipv4_forward_packet(struct net_pkt *pkt, struct net_ipv4_hdr *hdr,
+						   struct net_pkt_data_access *ipv4_access)
+{
+	ARG_UNUSED(pkt);
+	ARG_UNUSED(hdr);
+	ARG_UNUSED(ipv4_access);
+
+	return NET_DROP;
+}
+#endif /* CONFIG_NET_IPV4_FORWARDING */
+
 enum net_verdict net_ipv4_input(struct net_pkt *pkt)
 {
 	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(ipv4_access, struct net_ipv4_hdr);
@@ -358,6 +473,10 @@ enum net_verdict net_ipv4_input(struct net_pkt *pkt)
 		net_dhcpv4_accept_unicast(pkt)))) ||
 	    (hdr->proto == IPPROTO_TCP &&
 	     net_ipv4_is_addr_bcast_raw(net_pkt_iface(pkt), hdr->dst))) {
+		if (ipv4_forward_packet(pkt, hdr, &ipv4_access) == NET_OK) {
+			return NET_OK;
+		}
+
 		NET_DBG("DROP: not for me");
 		goto drop;
 	}

--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -444,4 +444,19 @@ config NET_SOCKETS_OBJ_CORE
 	  The net-shell "net sockets" command will use this functionality
 	  to show the socket information.
 
+config NET_SOCKETS_RECV_QUEUE_LIMIT
+	int "Maximum packets queued on a single socket receive queue (0 = unlimited)"
+	default 0
+	help
+	  Bound how many packets one socket can hold, so a stalled reader cannot
+	  absorb every buffer in the global net_pkt pool. 0 is unbounded.
+
+config NET_SOCKETS_RECV_QUEUE_RESERVE
+	int "Free RX packets below which the per-socket limit is enforced"
+	default 10
+	depends on NET_SOCKETS_RECV_QUEUE_LIMIT > 0
+	help
+	  The limit is only applied once free RX buffers fall below this, so a system
+	  that is not short of buffers behaves as it does without it.
+
 endif # NET_SOCKETS

--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -53,6 +53,38 @@ static void zsock_received_cb(struct net_context *ctx,
 			      int status,
 			      void *user_data);
 
+#if CONFIG_NET_SOCKETS_RECV_QUEUE_LIMIT > 0
+/* Only drops once the pool is low */
+static bool recv_queue_should_drop(struct net_context *ctx)
+{
+	struct k_mem_slab *rx_slab, *tx_slab;
+	struct net_buf_pool *rx_data, *tx_data;
+	sys_sfnode_t *node;
+	int depth = 0;
+	bool over_limit = false;
+
+	net_pkt_get_info(&rx_slab, &tx_slab, &rx_data, &tx_data);
+
+	if (k_mem_slab_num_free_get(rx_slab) > CONFIG_NET_SOCKETS_RECV_QUEUE_RESERVE) {
+		return false;
+	}
+
+	/* Must hold the scheduler, the reader pops from this same list */
+	k_sched_lock();
+	SYS_SFLIST_FOR_EACH_NODE(&ctx->recv_q._queue.data_q, node) {
+		depth++;
+
+		if (depth >= CONFIG_NET_SOCKETS_RECV_QUEUE_LIMIT) {
+			over_limit = true;
+			break;
+		}
+	}
+	k_sched_unlock();
+
+	return over_limit;
+}
+#endif
+
 static int fifo_wait_non_empty(struct k_fifo *fifo, k_timeout_t timeout)
 {
 	struct k_poll_event events[] = {
@@ -279,6 +311,20 @@ static void zsock_received_cb(struct net_context *ctx,
 	net_pkt_set_eof(pkt, false);
 
 	net_pkt_set_rx_stats_tick(pkt, k_cycle_get_32());
+
+#if CONFIG_NET_SOCKETS_RECV_QUEUE_LIMIT > 0
+	if (recv_queue_should_drop(ctx)) {
+		NET_WARN("ctx=%p at the receive queue limit with the RX pool low, dropping pkt=%p",
+			 ctx, pkt);
+		if (net_context_get_proto(ctx) == IPPROTO_TCP) {
+			net_stats_update_tcp_drop(net_pkt_iface(pkt));
+		} else {
+			net_stats_update_udp_drop(net_pkt_iface(pkt));
+		}
+		net_pkt_unref(pkt);
+		goto unlock;
+	}
+#endif
 
 	k_fifo_put(&ctx->recv_q, pkt);
 

--- a/subsys/shell/backends/Kconfig.backends
+++ b/subsys/shell/backends/Kconfig.backends
@@ -536,6 +536,21 @@ config SHELL_TELNET_LINE_BUF_SIZE
 	  A lot of short lines: better reduce this value. On the contrary,
 	  raise it.
 
+config SHELL_TELNET_RESTART
+	bool "Retry the listening socket after it goes down"
+	default y
+	help
+	  If set, reopen the listening socket instead of unregistering the backend
+	  until power cycle.
+
+config SHELL_TELNET_RESTART_RETRY_MS
+	int "Delay in milliseconds between attempts to reopen the socket"
+	default 1000
+	depends on SHELL_TELNET_RESTART
+	help
+	  Default to one second, which is is more than enough time for the socket
+		to be released.
+
 config SHELL_TELNET_SEND_TIMEOUT
 	int "Telnet line send timeout"
 	default 100

--- a/subsys/shell/backends/shell_telnet.c
+++ b/subsys/shell/backends/shell_telnet.c
@@ -401,12 +401,31 @@ static void telnet_restart_server(void)
 		sh_telnet->fds[SOCK_ID_CLIENT].fd = -1;
 	}
 
+	/* Must unregister before telnet_init() registers again */
+	(void)net_socket_service_unregister(&telnet_server);
+
 	ret = telnet_init(sh_telnet);
 	if (ret < 0) {
-		LOG_ERR("Telnet fatal error, failed to restart server (%d)", ret);
-		(void)net_socket_service_unregister(&telnet_server);
+#if defined(CONFIG_SHELL_TELNET_RESTART)
+		/* Not fatal, an ordinary boot fails here once */
+		LOG_DBG("Telnet server not ready (%d), retrying in %d ms", ret,
+			CONFIG_SHELL_TELNET_RESTART_RETRY_MS);
+		k_work_reschedule(&sh_telnet->restart_work,
+				  K_MSEC(CONFIG_SHELL_TELNET_RESTART_RETRY_MS));
+#else
+		LOG_ERR("Telnet server could not be restarted (%d)", ret);
+#endif
 	}
 }
+
+#if defined(CONFIG_SHELL_TELNET_RESTART)
+static void telnet_restart_work_handler(struct k_work *work)
+{
+	ARG_UNUSED(work);
+
+	telnet_restart_server();
+}
+#endif
 
 static void telnet_accept(struct zsock_pollfd *pollfd)
 {
@@ -630,9 +649,19 @@ static int init(const struct shell_transport *transport,
 	sh_telnet->shell_handler = evt_handler;
 	sh_telnet->shell_context = context;
 
+#if defined(CONFIG_SHELL_TELNET_RESTART)
+	/* Must init before telnet_init(), which can schedule a retry immediately. */
+	k_work_init_delayable(&sh_telnet->restart_work, telnet_restart_work_handler);
+#endif
+
 	err = telnet_init(sh_telnet);
 	if (err != 0) {
-		return err;
+		/* The interface may not be up yet */
+		LOG_DBG("Telnet server not ready (%d)", err);
+#if defined(CONFIG_SHELL_TELNET_RESTART)
+		k_work_reschedule(&sh_telnet->restart_work,
+				  K_MSEC(CONFIG_SHELL_TELNET_RESTART_RETRY_MS));
+#endif
 	}
 
 	k_work_init_delayable(&sh_telnet->send_work, telnet_send_prematurely);


### PR DESCRIPTION
Followed the Zephyr commit structure, each commit should be pretty isolated and self-explainatory.
- Fixed a bug where a telnet interface could go down and keep the socket down forever. Now it retries.
- Fixed a bug where one socket could steal the entire pool, I added bounds to avoid greedy sockets.
- Added Wi-Fi bypass mode